### PR TITLE
prevent mkdir from complaining at second build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,13 +4,13 @@ function project_build ()
 {
   echo "Type=${1}, Tests=${2}, Static=${3}, Dev=${4}, j=${5}"
 
-  mkdir build
+  mkdir -p build
   cd build
 
   cmake .. -DCMAKE_BUILD_TYPE=${1} \
            -DWITH_TESTS=${2} \
            -DSTATIC_BUILD=${3} \
-           -DDEV_BUILD="${4}" \
+           -DDEV_BUILD="${4}"
   make -j${5}
 
   if [[ ${6} == 1 && $? == 0 ]]; then


### PR DESCRIPTION
prevent mkdir from complaining at second build (use of -p option)
prevent make from being seen at a argument of cmake